### PR TITLE
Current branch = [shortened] inner text -> button title

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -112,7 +112,7 @@ function addReadmeEditButton() {
 
 	const readmeName = $('#readme > h3').text().trim();
 	const path = $('.js-repo-root ~ .js-path-segment, .final-path').map((idx, el) => $(el).text()).get().join('/');
-	const currentBranch = $('.file-navigation .select-menu.float-left button.select-menu-button span').text();
+	const currentBranch = $('.file-navigation .select-menu.float-left button.select-menu-button').attr('title');
 	const editHref = `/${repoUrl}/edit/${currentBranch}/${path ? `${path}/` : ''}${readmeName}`;
 	const editButtonHtml = `<div id="refined-github-readme-edit-link">
 		<a href="${editHref}">

--- a/extension/content.js
+++ b/extension/content.js
@@ -112,7 +112,8 @@ function addReadmeEditButton() {
 
 	const readmeName = $('#readme > h3').text().trim();
 	const path = $('.js-repo-root ~ .js-path-segment, .final-path').map((idx, el) => $(el).text()).get().join('/');
-	const currentBranch = $('.file-navigation .select-menu.float-left button.select-menu-button').attr('title');
+	const selectMenuButton = $('.file-navigation .select-menu.float-left button.select-menu-button');
+	const currentBranch = selectMenuButton.attr('title') || selectMenuButton.find('span').text();
 	const editHref = `/${repoUrl}/edit/${currentBranch}/${path ? `${path}/` : ''}${readmeName}`;
 	const editButtonHtml = `<div id="refined-github-readme-edit-link">
 		<a href="${editHref}">


### PR DESCRIPTION
The dropdown/button has a fixed width, so the title is sometimes shortened to fit, and an ellipsis is added at the end. This change reads the current branch name from the button’s `title` attribute instead, where it’s not affected by the visual space limitations.